### PR TITLE
Migrate to PyPI trusted publisher

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,11 @@ jobs:
   ci:
     name: Build and test wheel distribution
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/photoshop-connection
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -34,5 +39,3 @@ jobs:
       - name: Publish package
         if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR migrates the CI deployment workflow to the trusted publisher